### PR TITLE
chore: optimize npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,22 @@
 {
   "name": "@turbopush/react-native-code-push",
-  "version": "10.2.4",
+  "version": "10.2.6",
   "description": "React Native plugin for the CodePush service",
   "main": "CodePush.js",
   "typings": "typings/react-native-code-push.d.ts",
+  "files": [
+    "android/",
+    "ios/",
+    "scripts/",
+    "typings/",
+    "AlertAdapter.js",
+    "CodePush.js",
+    "CodePush.podspec",
+    "logging.js",
+    "package-mixins.js",
+    "react-native.config.js",
+    "request-fetch-adapter.js"
+  ],
   "homepage": "https://turbopush.org",
   "keywords": [
     "react-native",


### PR DESCRIPTION
- Bump version from 10.2.4 to 10.2.6
- Add files field to package.json to explicitly define which files are included in the npm package, excluding dev artifacts like test apps, testing framework, and example projects